### PR TITLE
Add possibility report reports problems to CEL 

### DIFF
--- a/README
+++ b/README
@@ -95,7 +95,7 @@ $  java -agentlib:abrt-java-connector=journald=off $MyClass -platform.jvmtiSuppo
 - enable syslog
 $  java -agentlib:abrt-java-connector=syslog=on $MyClass -platform.jvmtiSupported true
 
-Example5:
+Example6:
 - this example shows how to configure abrt-java-connector to fill 'executable'
   ABRT file with a path to a class on the bottom of the stack trace (the first
   method of thread)
@@ -108,7 +108,7 @@ $  java -agentlib:abrt-java-connector=executable=threadclass $MyClass -platform.
   file is filled with full path $MyClass
 
 
-Example6:
+Example7:
 - this example shows how to enrich the exception report with extra debug information
 - abrt-java-connector is capable to call a static method returning String at
   time of processing exception
@@ -119,13 +119,21 @@ Example6:
 $  java -agentlib:abrt-java-connector=debugmethod=com.example.$MyClass.getMethod $MyClass
 
 
-Example7:
+Example8:
 - this example shows how to change the path to configuration file
 - the default configuration file path is '/etc/abrt/plugins/java.conf'
 - empty 'conffile' option means do not read any configuration file
 
 
 $  java -agentlib:abrt-java-connector=conffile=/etc/foo/example.conf $MyClass
+
+
+Example9:
+- this example shows how to enable reporting errors to container-exception-logger (cel)
+- cel gets enabled by passing option 'cel' with value 'on'
+- container-exception-logger has to be installed in a container
+
+$  java -agentlib:abrt-java-connector=cel=on $MyClass -platform.jvmtiSupported true
 
 
 Building from sources

--- a/etc/java.conf
+++ b/etc/java.conf
@@ -15,6 +15,10 @@ abrt = on
 # Default value: on
 # journald = off
 
+# If enabled, exception reports are written to container-exception-logger (CEL)
+# Default value: off
+# cel = on
+
 # Path to directory or file for writing exception reports.
 # Default value: <empty string = means no log file>
 # output = /tmp/

--- a/package/abrt-java-connector.spec
+++ b/package/abrt-java-connector.spec
@@ -27,6 +27,17 @@ Requires:	abrt
 JNI library providing an agent capable to process both caught and uncaught
 exceptions and transform them to ABRT problems
 
+%package container
+Summary: JNI Agent library converting Java exceptions to ABRT problems (minimal version)
+Requires: container-exception-logger
+conflicts: %{name}
+
+%description container
+JNI library providing an agent capable to process both caught and uncaught
+exceptions and transform them to ABRT problems
+
+This package contains only minimal set of files needed for container exception
+logging.
 
 %prep
 %setup -qn %{name}-%{commit}
@@ -41,7 +52,8 @@ make %{?_smp_mflags}
 make install DESTDIR=%{buildroot}
 
 %files
-%doc LICENSE README AUTHORS
+%doc README AUTHORS
+%license LICENSE
 %config(noreplace) %{_sysconfdir}/libreport/plugins/bugzilla_format_java.conf
 %config(noreplace) %{_sysconfdir}/libreport/plugins/bugzilla_formatdup_java.conf
 %config(noreplace) %{_sysconfdir}/libreport/events.d/java_event.conf
@@ -53,6 +65,16 @@ make install DESTDIR=%{buildroot}
 %{_mandir}/man5/bugzilla_formatdup_java.conf.5*
 %{_datadir}/abrt/conf.d/plugins/java.conf
 
+# Applications may use a single subdirectory under/usr/lib.
+# http://www.pathname.com/fhs/pub/fhs-2.3.html#PURPOSE22
+#
+# Java does not support multilib.
+# https://fedorahosted.org/fesco/ticket/961
+%{_prefix}/lib/abrt-java-connector
+
+%files container
+%doc README AUTHORS
+%license LICENSE
 # Applications may use a single subdirectory under/usr/lib.
 # http://www.pathname.com/fhs/pub/fhs-2.3.html#PURPOSE22
 #

--- a/src/abrt-checker.h
+++ b/src/abrt-checker.h
@@ -67,6 +67,7 @@ typedef enum {
     ED_ABRT     = ED_TERMINAL << 1, ///< Submit error reports to ABRT
     ED_SYSLOG   = ED_ABRT << 1,     ///< Submit error reports to syslog
     ED_JOURNALD = ED_SYSLOG << 1,   ///< Submit error reports to journald
+    ED_CEL      = ED_JOURNALD << 1, ///< Submit error reports to container-exception-logger
 } T_errorDestination;
 
 

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -18,6 +18,7 @@ enum {
     OPT_executable   = 1 << 5,
     OPT_conffile     = 1 << 6,
     OPT_debugmethod  = 1 << 7,
+    OPT_cel          = 1 << 8,
 };
 
 
@@ -148,6 +149,19 @@ static int parse_option_abrt(T_configuration *conf, const char *value, T_context
     {
         VERBOSE_PRINT("Enabling errors reporting to ABRT\n");
         conf->reportErrosTo |= ED_ABRT;
+    }
+
+    return 0;
+}
+
+
+
+static int parse_option_cel(T_configuration *conf, const char *value, T_context *context __UNUSED_VAR)
+{
+    if (value != NULL && (strcasecmp("on", value) == 0 || strcasecmp("yes", value) == 0))
+    {
+        VERBOSE_PRINT("Enabling errors reporting to container-exception-logger\n");
+        conf->reportErrosTo |= ED_CEL;
     }
 
     return 0;
@@ -311,6 +325,7 @@ static void parse_key_value(T_configuration *conf, const char *key, const char *
         { OPT_executable, "executable", parse_option_executable },
         { OPT_conffile, "conffile", parse_option_conffile },
         { OPT_debugmethod, "debugmethod", parse_option_debugmethod },
+        { OPT_cel, "cel", parse_option_cel },
     };
 
     for (size_t i = 0; i < sizeof(arguments)/sizeof(arguments[0]); ++i)

--- a/test/outputs/Linux-aarch64/run_test.log.in
+++ b/test/outputs/Linux-aarch64/run_test.log.in
@@ -27,7 +27,7 @@ Exception in thread "main" java.io.FileNotFoundException: /root/.bashrc (Permiss
 	at Test.main(Test.java:513) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
 Caught exception java.net.UnknownHostException in method java.net.Inet6AddressImpl.lookupAllHostAddr()
-Exception in thread "main" java.net.UnknownHostException: xyzzy: unknown error
+Exception in thread "main" java.net.UnknownHostException: xyzzy: Name or service not known
 	at java.net.Inet6AddressImpl.lookupAllHostAddr(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/Inet6AddressImpl.class]
 	at java.net.InetAddress$2.lookupAllHostAddr(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress$2.class]
 	at java.net.InetAddress.getAddressesFromNameService(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress.class]
@@ -54,7 +54,7 @@ Exception in thread "main" java.net.UnknownHostException: xyzzy
 	at Test.main(Test.java:514) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
 Caught exception java.net.ConnectException in method java.net.PlainSocketImpl.socketConnect()
-Exception in thread "main" java.net.ConnectException: Connection refused
+Exception in thread "main" java.net.ConnectException: Connection refused (Connection refused)
 	at java.net.PlainSocketImpl.socketConnect(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/PlainSocketImpl.class]
 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/AbstractPlainSocketImpl.class]
 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/AbstractPlainSocketImpl.class]

--- a/test/outputs/Linux-armv7l/run_test.log.in
+++ b/test/outputs/Linux-armv7l/run_test.log.in
@@ -27,7 +27,7 @@ Exception in thread "main" java.io.FileNotFoundException: /root/.bashrc (Permiss
 	at Test.main(Test.java:513) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
 Caught exception java.net.UnknownHostException in method java.net.InetAddress$2.lookupAllHostAddr()
-Exception in thread "main" java.net.UnknownHostException: xyzzy: unknown error
+Exception in thread "main" java.net.UnknownHostException: xyzzy: Name or service not known
 	at java.net.Inet6AddressImpl.lookupAllHostAddr(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/Inet6AddressImpl.class]
 	at java.net.InetAddress$2.lookupAllHostAddr(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress$2.class]
 	at java.net.InetAddress.getAddressesFromNameService(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress.class]
@@ -54,7 +54,7 @@ Exception in thread "main" java.net.UnknownHostException: xyzzy
 	at Test.main(Test.java:514) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
 Caught exception java.net.ConnectException in method java.net.AbstractPlainSocketImpl.doConnect()
-Exception in thread "main" java.net.ConnectException: Connection refused
+Exception in thread "main" java.net.ConnectException: Connection refused (Connection refused)
 	at java.net.PlainSocketImpl.socketConnect(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/PlainSocketImpl.class]
 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/AbstractPlainSocketImpl.class]
 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/AbstractPlainSocketImpl.class]

--- a/test/outputs/Linux-armv7l/run_test.log.in.java-1.7
+++ b/test/outputs/Linux-armv7l/run_test.log.in.java-1.7
@@ -70,7 +70,7 @@ Exception in thread "main" java.net.UnknownHostException: xyzzy
 	at Test.main(Test.java:514) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
 Caught exception java.net.ConnectException in method java.net.AbstractPlainSocketImpl.doConnect()
-Exception in thread "main" java.net.ConnectException: Connection refused
+Exception in thread "main" java.net.ConnectException: Connection refused (Connection refused)
 	at java.net.PlainSocketImpl.socketConnect(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/PlainSocketImpl.class]
 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/AbstractPlainSocketImpl.class]
 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/AbstractPlainSocketImpl.class]

--- a/test/outputs/Linux-ppc64/run_test.log.in
+++ b/test/outputs/Linux-ppc64/run_test.log.in
@@ -27,7 +27,7 @@ Exception in thread "main" java.io.FileNotFoundException: /root/.bashrc (Permiss
 	at Test.main(Test.java:513) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
 Caught exception java.net.UnknownHostException in method java.net.InetAddress$2.lookupAllHostAddr()
-Exception in thread "main" java.net.UnknownHostException: xyzzy: unknown error
+Exception in thread "main" java.net.UnknownHostException: xyzzy: Name or service not known
 	at java.net.Inet6AddressImpl.lookupAllHostAddr(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/Inet6AddressImpl.class]
 	at java.net.InetAddress$2.lookupAllHostAddr(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress$2.class]
 	at java.net.InetAddress.getAddressesFromNameService(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress.class]
@@ -54,7 +54,7 @@ Exception in thread "main" java.net.UnknownHostException: xyzzy
 	at Test.main(Test.java:514) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
 Caught exception java.net.ConnectException in method java.net.AbstractPlainSocketImpl.doConnect()
-Exception in thread "main" java.net.ConnectException: Connection refused
+Exception in thread "main" java.net.ConnectException: Connection refused (Connection refused)
 	at java.net.PlainSocketImpl.socketConnect(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/PlainSocketImpl.class]
 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/AbstractPlainSocketImpl.class]
 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/AbstractPlainSocketImpl.class]

--- a/test/outputs/Linux-ppc64le/run_test.log.in
+++ b/test/outputs/Linux-ppc64le/run_test.log.in
@@ -27,7 +27,7 @@ Exception in thread "main" java.io.FileNotFoundException: /root/.bashrc (Permiss
 	at Test.main(Test.java:513) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
 Caught exception java.net.UnknownHostException in method java.net.InetAddress$2.lookupAllHostAddr()
-Exception in thread "main" java.net.UnknownHostException: xyzzy: unknown error
+Exception in thread "main" java.net.UnknownHostException: xyzzy: Name or service not known
 	at java.net.Inet6AddressImpl.lookupAllHostAddr(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/Inet6AddressImpl.class]
 	at java.net.InetAddress$2.lookupAllHostAddr(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress$2.class]
 	at java.net.InetAddress.getAddressesFromNameService(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress.class]
@@ -54,7 +54,7 @@ Exception in thread "main" java.net.UnknownHostException: xyzzy
 	at Test.main(Test.java:514) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
 Caught exception java.net.ConnectException in method java.net.AbstractPlainSocketImpl.doConnect()
-Exception in thread "main" java.net.ConnectException: Connection refused
+Exception in thread "main" java.net.ConnectException: Connection refused (Connection refused)
 	at java.net.PlainSocketImpl.socketConnect(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/PlainSocketImpl.class]
 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/AbstractPlainSocketImpl.class]
 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/AbstractPlainSocketImpl.class]

--- a/test/outputs/Linux-s390/run_test.log.in
+++ b/test/outputs/Linux-s390/run_test.log.in
@@ -1,22 +1,25 @@
-Caught exception java.io.FileNotFoundException in method java.io.FileInputStream.<init>()
+Caught exception java.io.FileNotFoundException in method java.io.FileInputStream.open()
 Exception in thread "main" java.io.FileNotFoundException: _wrong_file_ (No such file or directory)
-	at java.io.FileInputStream.open(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileInputStream.class]
+	at java.io.FileInputStream.open0(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileInputStream.class]
+	at java.io.FileInputStream.open(FileInputStream.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileInputStream.class]
 	at java.io.FileInputStream.<init>(FileInputStream.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileInputStream.class]
 	at Test.readWrongFile(Test.java:89) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 	at Test.fileRelatedIssues(Test.java:461) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 	at Test.main(Test.java:513) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
-Caught exception java.io.FileNotFoundException in method java.io.FileInputStream.<init>()
+Caught exception java.io.FileNotFoundException in method java.io.FileInputStream.open()
 Exception in thread "main" java.io.FileNotFoundException: /root/.bashrc (Permission denied)
-	at java.io.FileInputStream.open(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileInputStream.class]
+	at java.io.FileInputStream.open0(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileInputStream.class]
++	at java.io.FileInputStream.open(FileInputStream.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileInputStream.class]
 	at java.io.FileInputStream.<init>(FileInputStream.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileInputStream.class]
 	at Test.readUnreadableFile(Test.java:111) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 	at Test.fileRelatedIssues(Test.java:462) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 	at Test.main(Test.java:513) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
-Caught exception java.io.FileNotFoundException in method java.io.FileOutputStream.<init>()
+Caught exception java.io.FileNotFoundException in method java.io.FileOutputStream.open()
 Exception in thread "main" java.io.FileNotFoundException: /root/.bashrc (Permission denied)
-	at java.io.FileOutputStream.open(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileOutputStream.class]
+	at java.io.FileOutputStream.open0(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileOutputStream.class]
+	at java.io.FileOutputStream.open(FileOutputStream.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileOutputStream.class]
 	at java.io.FileOutputStream.<init>(FileOutputStream.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileOutputStream.class]
 	at java.io.FileOutputStream.<init>(FileOutputStream.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileOutputStream.class]
 	at Test.writeToUnwritableFile(Test.java:134) [file:@CMAKE_BINARY_DIR@/test/Test.class]
@@ -24,7 +27,7 @@ Exception in thread "main" java.io.FileNotFoundException: /root/.bashrc (Permiss
 	at Test.main(Test.java:513) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
 Caught exception java.net.UnknownHostException in method java.net.InetAddress$2.lookupAllHostAddr()
-Exception in thread "main" java.net.UnknownHostException: xyzzy: unknown error
+Exception in thread "main" java.net.UnknownHostException: xyzzy: Name or service not known
 	at java.net.Inet6AddressImpl.lookupAllHostAddr(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/Inet6AddressImpl.class]
 	at java.net.InetAddress$2.lookupAllHostAddr(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress$2.class]
 	at java.net.InetAddress.getAddressesFromNameService(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress.class]
@@ -51,7 +54,7 @@ Exception in thread "main" java.net.UnknownHostException: xyzzy
 	at Test.main(Test.java:514) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
 Caught exception java.net.ConnectException in method java.net.AbstractPlainSocketImpl.doConnect()
-Exception in thread "main" java.net.ConnectException: Connection refused
+Exception in thread "main" java.net.ConnectException: (Connection refused)
 	at java.net.PlainSocketImpl.socketConnect(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/PlainSocketImpl.class]
 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/AbstractPlainSocketImpl.class]
 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/AbstractPlainSocketImpl.class]

--- a/test/outputs/Linux-s390x/run_test.log.in
+++ b/test/outputs/Linux-s390x/run_test.log.in
@@ -1,22 +1,25 @@
-Caught exception java.io.FileNotFoundException in method java.io.FileInputStream.<init>()
+Caught exception java.io.FileNotFoundException in method java.io.FileInputStream.open()
 Exception in thread "main" java.io.FileNotFoundException: _wrong_file_ (No such file or directory)
-	at java.io.FileInputStream.open(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileInputStream.class]
+	at java.io.FileInputStream.open0(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileInputStream.class]
+	at java.io.FileInputStream.open(FileInputStream.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileInputStream.class]
 	at java.io.FileInputStream.<init>(FileInputStream.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileInputStream.class]
 	at Test.readWrongFile(Test.java:89) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 	at Test.fileRelatedIssues(Test.java:461) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 	at Test.main(Test.java:513) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
-Caught exception java.io.FileNotFoundException in method java.io.FileInputStream.<init>()
+Caught exception java.io.FileNotFoundException in method java.io.FileInputStream.open()
 Exception in thread "main" java.io.FileNotFoundException: /root/.bashrc (Permission denied)
-	at java.io.FileInputStream.open(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileInputStream.class]
+	at java.io.FileInputStream.open0(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileInputStream.class]
+	at java.io.FileInputStream.open(FileInputStream.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileInputStream.class]
 	at java.io.FileInputStream.<init>(FileInputStream.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileInputStream.class]
 	at Test.readUnreadableFile(Test.java:111) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 	at Test.fileRelatedIssues(Test.java:462) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 	at Test.main(Test.java:513) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
-Caught exception java.io.FileNotFoundException in method java.io.FileOutputStream.<init>()
+Caught exception java.io.FileNotFoundException in method java.io.FileOutputStream.open()
 Exception in thread "main" java.io.FileNotFoundException: /root/.bashrc (Permission denied)
-	at java.io.FileOutputStream.open(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileOutputStream.class]
+	at java.io.FileOutputStream.open0(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileOutputStream.class]
+	at java.io.FileOutputStream.open(FileOutputStream.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileOutputStream.class]
 	at java.io.FileOutputStream.<init>(FileOutputStream.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileOutputStream.class]
 	at java.io.FileOutputStream.<init>(FileOutputStream.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/io/FileOutputStream.class]
 	at Test.writeToUnwritableFile(Test.java:134) [file:@CMAKE_BINARY_DIR@/test/Test.class]
@@ -24,7 +27,7 @@ Exception in thread "main" java.io.FileNotFoundException: /root/.bashrc (Permiss
 	at Test.main(Test.java:513) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
 Caught exception java.net.UnknownHostException in method java.net.InetAddress$2.lookupAllHostAddr()
-Exception in thread "main" java.net.UnknownHostException: xyzzy: unknown error
+Exception in thread "main" java.net.UnknownHostException: xyzzy: Name or service not known
 	at java.net.Inet6AddressImpl.lookupAllHostAddr(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/Inet6AddressImpl.class]
 	at java.net.InetAddress$2.lookupAllHostAddr(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress$2.class]
 	at java.net.InetAddress.getAddressesFromNameService(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress.class]
@@ -51,7 +54,7 @@ Exception in thread "main" java.net.UnknownHostException: xyzzy
 	at Test.main(Test.java:514) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
 Caught exception java.net.ConnectException in method java.net.AbstractPlainSocketImpl.doConnect()
-Exception in thread "main" java.net.ConnectException: Connection refused
+Exception in thread "main" java.net.ConnectException: Connection refused (Connection refused)
 	at java.net.PlainSocketImpl.socketConnect(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/PlainSocketImpl.class]
 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/AbstractPlainSocketImpl.class]
 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/AbstractPlainSocketImpl.class]

--- a/test/outputs/run_test.log.in
+++ b/test/outputs/run_test.log.in
@@ -27,7 +27,7 @@ Exception in thread "main" java.io.FileNotFoundException: /root/.bashrc (Permiss
 	at Test.main(Test.java:513) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
 Caught exception java.net.UnknownHostException in method java.net.Inet6AddressImpl.lookupAllHostAddr()
-Exception in thread "main" java.net.UnknownHostException: xyzzy: unknown error
+Exception in thread "main" java.net.UnknownHostException: xyzzy: Name or service not known
 	at java.net.Inet6AddressImpl.lookupAllHostAddr(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/Inet6AddressImpl.class]
 	at java.net.InetAddress$2.lookupAllHostAddr(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress$2.class]
 	at java.net.InetAddress.getAddressesFromNameService(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress.class]
@@ -54,7 +54,7 @@ Exception in thread "main" java.net.UnknownHostException: xyzzy
 	at Test.main(Test.java:514) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
 Caught exception java.net.ConnectException in method java.net.PlainSocketImpl.socketConnect()
-Exception in thread "main" java.net.ConnectException: Connection refused
+Exception in thread "main" java.net.ConnectException: Connection refused (Connection refused)
 	at java.net.PlainSocketImpl.socketConnect(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/PlainSocketImpl.class]
 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/AbstractPlainSocketImpl.class]
 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/AbstractPlainSocketImpl.class]

--- a/test/outputs/run_test.log.in.java-1.7
+++ b/test/outputs/run_test.log.in.java-1.7
@@ -70,7 +70,7 @@ Exception in thread "main" java.net.UnknownHostException: xyzzy
 	at Test.main(Test.java:514) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
 Caught exception java.net.ConnectException in method java.net.PlainSocketImpl.socketConnect()
-Exception in thread "main" java.net.ConnectException: Connection refused
+Exception in thread "main" java.net.ConnectException: Connection refused (Connection refused)
 	at java.net.PlainSocketImpl.socketConnect(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/PlainSocketImpl.class]
 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/AbstractPlainSocketImpl.class]
 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/AbstractPlainSocketImpl.class]

--- a/utils/abrt-action-analyze-java.c
+++ b/utils/abrt-action-analyze-java.c
@@ -335,7 +335,7 @@ int main(int argc, char *argv[])
     {
         hash_str = sr_thread_get_duphash(crash_thread, FRAMES_FOR_DUPHASH,
                 /*noprefix*/NULL, SR_DUPHASH_NOHASH);
-        log("Generating duphash from string: '%s'", hash_str);
+        log_warning("Generating duphash from string: '%s'", hash_str);
         free(hash_str);
     }
 


### PR DESCRIPTION
container-exception-logger (CEL) is a tool which allows
report from a container to the host's log.

The following example shows how to enable reporting to CEL
  $ java -agentlib:abrt-java-connector=cel=on $MyClass -platform.jvmtiSupported true
