### PR TITLE
FTBFS Fixes

### DIFF
--- a/src/abrt-checker.c
+++ b/src/abrt-checker.c
@@ -1308,7 +1308,7 @@ static char *get_main_class(
         if (realpath(class_name, jarpath) == NULL)
         {
             fprintf(stderr, "Error %d: Could get real path of '%s'\n", errno, class_name);
-            strncpy(jarpath, class_name, sizeof(jarpath));
+            strncpy(jarpath, class_name, PATH_MAX);
         }
 
         char *executable = strdup(jarpath);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -304,7 +304,7 @@ add_test(test_no_log_file make run_no_log_file)
 
 add_custom_target(
     run_log_file_in_directory
-    COMMAND rm -rf ${CMAKE_CURRENT_BINARY_DIR}/lid && mkdir ${CMAKE_CURRENT_BINARY_DIR}/lid && LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/src ${Java_JAVA_EXECUTABLE} -agentlib:${AGENT_NAME}=output=${CMAKE_CURRENT_BINARY_DIR}/lid Test || test -n `find ${CMAKE_CURRENT_BINARY_DIR}/lid -name "abrt_checker_*.log"`
+    COMMAND rm -rf ${CMAKE_CURRENT_BINARY_DIR}/lid && mkdir ${CMAKE_CURRENT_BINARY_DIR}/lid && LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/src ${Java_JAVA_EXECUTABLE} -agentlib:${AGENT_NAME}=output=${CMAKE_CURRENT_BINARY_DIR}/lid Test || test -n "$(find ${CMAKE_CURRENT_BINARY_DIR}/lid -name \"abrt_checker_*.log\")"
     DEPENDS AbrtChecker ${TEST_JAVA_TARGETS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
@@ -312,7 +312,7 @@ add_test(test_log_file_in_directory make run_log_file_in_directory)
 
 add_custom_target(
     run_default_no_log_file
-    COMMAND LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/src ${Java_JAVA_EXECUTABLE} -agentlib:${AGENT_NAME} Test || test -z "`find -name abrt_checker_*.log`"
+    COMMAND LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/src ${Java_JAVA_EXECUTABLE} -agentlib:${AGENT_NAME} Test || test -z "$(find -name abrt_checker_*.log)"
     DEPENDS AbrtChecker ${TEST_JAVA_TARGETS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )


### PR DESCRIPTION
The Fedora Rawhide build fails to build:
https://kojipkgs.fedoraproject.org/work/tasks/831/35450831/build.log

```
If the length of the source string is equal to or greater than this size the result of the copy
will not be NUL-terminated. Therefore, the call is also diagnosed. To avoid the warning,
specify sizeof buf - 1 as the bound and set the last element of the buffer to NUL.
```
See:
[gcc.gnu.org/onlinedocs/gcc-8.1.0/gcc/Warning-Options.html#index-Wstringop-truncation](gcc.gnu.org/onlinedocs/gcc-8.1.0/gcc/Warning-Options.html#index-Wstringop-truncation)

Resolves: rhbz#1674628