### PR TITLE
Add libreport_ to libreport function calls and globals

### DIFF
--- a/src/abrt-checker.c
+++ b/src/abrt-checker.c
@@ -596,7 +596,7 @@ static void add_process_properties_data(problem_data_t *pd)
 {
     pid_t pid = getpid();
 
-    char *environ = get_environ(pid);
+    char *environ = libreport_get_environ(pid);
     problem_data_add_text_editable(pd, FILENAME_ENVIRON, environ ? environ : "");
     free(environ);
 
@@ -643,7 +643,7 @@ static char *escape_newline_chars(const char *str)
     if (NULL == mem)
     {
         perror("ERROR: failed to open memstream");
-        return xasprintf("Error in abrt-java-connector: failed to open memstream");
+        return libreport_xasprintf("Error in abrt-java-connector: failed to open memstream");
     }
 
     for (int i = 0; str[i] != '\0'; ++i)
@@ -674,18 +674,18 @@ static void write_to_cel(
 
     char *bt_escaped_newline = escape_newline_chars(backtrace);
 
-    char *json = xasprintf("{\"%s\": \"%s\", "
-                            "\"%s\": \"%s\", "
-                            "\"%s\": \"%s\", "
-                            "\"%s\": \"%s\", "
-                            "\"%s\": \"%s\", "
-                            "\"%s\": \"%s\"}\n",
-                            FILENAME_TYPE, FILENAME_TYPE_VALUE, /* type */
-                            FILENAME_EXECUTABLE, executable, /* executable */
-                            FILENAME_REASON, message, /* reason */
-                            FILENAME_BACKTRACE, bt_escaped_newline, /* backtrace */
-                            FILENAME_UID, uid, /* uid */
-                            "abrt-java-connector", VERSION);
+    char *json = libreport_xasprintf("{\"%s\": \"%s\", "
+                                      "\"%s\": \"%s\", "
+                                      "\"%s\": \"%s\", "
+                                      "\"%s\": \"%s\", "
+                                      "\"%s\": \"%s\", "
+                                      "\"%s\": \"%s\"}\n",
+                                     FILENAME_TYPE, FILENAME_TYPE_VALUE, /* type */
+                                     FILENAME_EXECUTABLE, executable, /* executable */
+                                     FILENAME_REASON, message, /* reason */
+                                     FILENAME_BACKTRACE, bt_escaped_newline, /* backtrace */
+                                     FILENAME_UID, uid, /* uid */
+                                     "abrt-java-connector", VERSION);
 
     free(bt_escaped_newline);
 
@@ -1167,7 +1167,7 @@ char *get_executable(int pid)
     char buf[sizeof("/proc/%lu/exe") + sizeof(long)*3];
 
     sprintf(buf, "/proc/%lu/exe", (long)pid);
-    char *executable = malloc_readlink(buf);
+    char *executable = libreport_malloc_readlink(buf);
     if (!executable)
     {
         fprintf(stderr, __FILE__ ":" STRINGIZE(__LINE__) ": can't read executable name from /proc/${PID}/exe");

--- a/src/abrt-checker.c
+++ b/src/abrt-checker.c
@@ -643,7 +643,7 @@ static char *escape_newline_chars(const char *str)
     if (NULL == mem)
     {
         perror("ERROR: failed to open memstream");
-        return libreport_xasprintf("Error in abrt-java-connector: failed to open memstream");
+        return g_strdup_printf("Error in abrt-java-connector: failed to open memstream");
     }
 
     for (int i = 0; str[i] != '\0'; ++i)
@@ -674,18 +674,18 @@ static void write_to_cel(
 
     char *bt_escaped_newline = escape_newline_chars(backtrace);
 
-    char *json = libreport_xasprintf("{\"%s\": \"%s\", "
-                                      "\"%s\": \"%s\", "
-                                      "\"%s\": \"%s\", "
-                                      "\"%s\": \"%s\", "
-                                      "\"%s\": \"%s\", "
-                                      "\"%s\": \"%s\"}\n",
-                                     FILENAME_TYPE, FILENAME_TYPE_VALUE, /* type */
-                                     FILENAME_EXECUTABLE, executable, /* executable */
-                                     FILENAME_REASON, message, /* reason */
-                                     FILENAME_BACKTRACE, bt_escaped_newline, /* backtrace */
-                                     FILENAME_UID, uid, /* uid */
-                                     "abrt-java-connector", VERSION);
+    char *json = g_strdup_printf("{\"%s\": \"%s\", "
+                                  "\"%s\": \"%s\", "
+                                  "\"%s\": \"%s\", "
+                                  "\"%s\": \"%s\", "
+                                  "\"%s\": \"%s\", "
+                                  "\"%s\": \"%s\"}\n",
+                                 FILENAME_TYPE, FILENAME_TYPE_VALUE, /* type */
+                                 FILENAME_EXECUTABLE, executable, /* executable */
+                                 FILENAME_REASON, message, /* reason */
+                                 FILENAME_BACKTRACE, bt_escaped_newline, /* backtrace */
+                                 FILENAME_UID, uid, /* uid */
+                                 "abrt-java-connector", VERSION);
 
     free(bt_escaped_newline);
 

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -401,10 +401,10 @@ void parse_commandline_options(T_configuration *conf, char *options)
 void parse_configuration_file(T_configuration *conf, const char *filename)
 {
     /* Remains empty if any of the loading functions below fails */
-    map_string_t *settings = new_map_string();
+    map_string_t *settings = libreport_new_map_string();
     if (filename[0] == '/')
     {
-        load_conf_file(filename, settings, /*skip empty*/0);
+        libreport_load_conf_file(filename, settings, /*skip empty*/0);
     }
     else
     {
@@ -417,13 +417,13 @@ void parse_configuration_file(T_configuration *conf, const char *filename)
     };
 
     map_string_iter_t iter;
-    init_map_string_iter(&iter, settings);
+    libreport_init_map_string_iter(&iter, settings);
     const char *key;
     const char *value;
-    while(next_map_string_iter(&iter, &key, &value))
+    while(libreport_next_map_string_iter(&iter, &key, &value))
     {
         parse_key_value(conf, key, value, &ctx);
     }
 
-    free_map_string(settings);
+    libreport_free_map_string(settings);
 }

--- a/utils/abrt-action-analyze-java.c
+++ b/utils/abrt-action-analyze-java.c
@@ -357,7 +357,7 @@ int main(int argc, char *argv[])
     if (NULL != remote_files_csv)
     {
         results_iter->name = FILENAME_NOT_REPORTABLE;
-        results_iter->data = libreport_xasprintf(
+        results_iter->data = g_strdup_printf(
         _("This problem can be caused by a 3rd party code from the "\
         "jar/class at %s. In order to provide valuable problem " \
         "reports, ABRT will not allow you to submit this problem. If you " \
@@ -369,7 +369,7 @@ int main(int argc, char *argv[])
     else if (contains_unkown_class(stacktrace))
     {
         results_iter->name = FILENAME_NOT_REPORTABLE;
-        results_iter->data = libreport_xasprintf(
+        results_iter->data = g_strdup_printf(
         _("This problem is not reportable because of the low quality of stack trace. " \
         "The stack trace contains lines having unknown source files and unknown " \
         "classes. Such stack traces are usually produced by a non-official code. " \
@@ -381,7 +381,7 @@ int main(int argc, char *argv[])
     else if ((opts & OPT_r) == 0 && contains_unpackaged_path(stacktrace))
     {
         results_iter->name = FILENAME_NOT_REPORTABLE;
-        results_iter->data = libreport_xasprintf(
+        results_iter->data = g_strdup_printf(
         _("This problem has been caused by a proprietary code which has not been "
         "provided any official package. Please contact the provider of the "
         "proprietary code.")


### PR DESCRIPTION
This PR fixes what abrt/libreport#609 breaks.

See also https://github.com/abrt/abrt/pull/1467

Signed-off-by: Michal Fabik <mfabik@redhat.com>