### PR TITLE
spec: Don’t build from git snapshot by default

### DIFF
--- a/package/abrt-java-connector.spec
+++ b/package/abrt-java-connector.spec
@@ -1,3 +1,4 @@
+%global snapshot 0
 %global commit bef7e39ce5fdc4a8a620d56be186d4463ed761a8
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
@@ -9,7 +10,11 @@ Summary:       JNI Agent library converting Java exceptions to ABRT problems
 Group:         System Environment/Libraries
 License:       GPLv2+
 URL:           https://github.com/abrt/abrt-java-connector
-Source0:       https://github.com/abrt/%{name}/archive/%{commit}/%{name}-%{version}-%{shortcommit}.tar.gz
+%if 0%{?snapshot}
+Source0:       %{url}/archive/%{commit}/%{name}-%{version}-%{shortcommit}.tar.gz
+%else
+Source0:       %{url}/archive/%{version}/%{name}-%{version}.tar.gz
+%endif
 
 BuildRequires: pkgconfig(abrt) >= 2.14.1
 BuildRequires: check-devel
@@ -42,7 +47,11 @@ This package contains only minimal set of files needed for container exception
 logging.
 
 %prep
+%if 0%{?snapshot}
 %autosetup -n %{name}-%{commit}
+%else
+%autosetup
+%endif
 
 
 %build


### PR DESCRIPTION
Currently, the spec file perpetually refers to an older commit,
preventing new releases from being built correctly. This commit adds a
new global to control whether to build a specified commit or use the
version.