### PR TITLE
Simplify spec, tweak tarball and (s)rpm versioning

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up build environment
         run: |
           dnf --assumeyes install @c-development diffutils dnf-plugins-core
-          dnf builddep --assumeyes --spec package/abrt-java-connector.spec
+          dnf builddep --assumeyes --spec abrt-java-connector.spec
 
       - name: Create build user
         run: useradd --no-create-home runner
@@ -49,7 +49,7 @@ jobs:
       - name: Set up build environment
         run: |
           dnf --assumeyes install @c-development diffutils dnf-plugins-core valgrind
-          dnf builddep --assumeyes --spec package/abrt-java-connector.spec
+          dnf builddep --assumeyes --spec abrt-java-connector.spec
 
       - name: Create build user
         run: useradd --no-create-home runner

--- a/.packit.yml
+++ b/.packit.yml
@@ -1,7 +1,7 @@
-specfile_path: package/abrt-java-connector.spec
+specfile_path: abrt-java-connector.spec
 synced_files:
   - .packit.yml
-  - package/abrt-java-connector.spec
+  - abrt-java-connector.spec
 upstream_package_name: abrt-java-connector
 upstream_project_url: https://github.com/abrt/abrt-java-connector
 downstream_package_name: abrt-java-connector

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,16 +19,16 @@ execute_process(
 
 if(git_result EQUAL 0)
     execute_process(
-        COMMAND git describe --tags --match "[0-9]*" --abbrev=0 HEAD
+        COMMAND git describe --tags --match "[0-9]*" HEAD
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         RESULT_VARIABLE git_result
         OUTPUT_VARIABLE git_tag
         ERROR_QUIET)
 
     if(git_result EQUAL 0)
-        string(REGEX REPLACE "(\r?\n)+$" "" git_short_commit "${git_short_commit}")
         string(REGEX REPLACE "(\r?\n)+$" "" git_tag "${git_tag}")
-        set(PROJECT_VERSION ${git_tag}-${git_short_commit})
+        string(REGEX REPLACE "-[0-9]+-g" ".g" git_tag "${git_tag}")
+        set(PROJECT_VERSION ${git_tag})
     endif()
 
     execute_process(
@@ -68,7 +68,7 @@ endif()
 
 add_custom_target(
     dist
-    COMMAND git archive --prefix=${CMAKE_PROJECT_NAME}-${git_commit}/ HEAD | gzip > ${CMAKE_BINARY_DIR}/${ARCHIVE_NAME}.tar.gz
+    COMMAND git archive --prefix=${CMAKE_PROJECT_NAME}-${git_tag}/ HEAD | gzip > ${CMAKE_BINARY_DIR}/${ARCHIVE_NAME}.tar.gz
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@
 
 
 OUT_DIR=bin
-PKG_DIR=package
 
 all: run
 
@@ -35,22 +34,20 @@ dist: $(OUT_DIR)
 
 RPM_DIRS = --define "_sourcedir `pwd`/$(OUT_DIR)" \
 		--define "_rpmdir `pwd`/$(OUT_DIR)" \
-		--define "_specdir `pwd`/$(PKG_DIR)" \
+		--define "_specdir `pwd`" \
 		--define "_builddir `pwd`/$(OUT_DIR)" \
 		--define "_srcrpmdir `pwd`/$(OUT_DIR)"
 
 .PHONY: rpm
 rpm: dist
-	sed -e 's/global commit .*$$/global commit '"$$(git log -1 --format=%H)"'/' \
-		-e 's/%{?dist}/.'"$$(git log -1 --format=%h)%{?dist}"'/' \
-		$(PKG_DIR)/abrt-java-connector.spec > $(OUT_DIR)/abrt-java-connector.spec && \
+	-test "$$(git describe --match="[0-9]*" --tags HEAD | sed 's/[0-9]\+\.[0-9]\+\.[0-9]\+//')" \
+		&& sed -e '/^Version:.*/s/$$/'"$$(git log -1 --format=.g%h)"'/' abrt-java-connector.spec > $(OUT_DIR)/abrt-java-connector.spec
 	rpmbuild $(RPM_DIRS) $(RPM_FLAGS) -ba $(OUT_DIR)/abrt-java-connector.spec
 
 .PHONY: srpm
 srpm: dist
-	sed -e 's/global commit .*$$/global commit '"$$(git log -1 --format=%H)"'/' \
-		-e 's/%{?dist}/.'"$$(git log -1 --format=%h)%{?dist}"'/' \
-		$(PKG_DIR)/abrt-java-connector.spec > $(OUT_DIR)/abrt-java-connector.spec && \
+	-test "$$(git describe --match="[0-9]*" --tags HEAD | sed 's/[0-9]\+\.[0-9]\+\.[0-9]\+//')" \
+		&& sed -e '/^Version:.*/s/$$/'"$$(git log -1 --format=.g%h)"'/' abrt-java-connector.spec > $(OUT_DIR)/abrt-java-connector.spec
 	rpmbuild $(RPM_DIRS) $(RPM_FLAGS) -bs $(OUT_DIR)/abrt-java-connector.spec
 
 # Make sure the output dir is created

--- a/abrt-java-connector.spec
+++ b/abrt-java-connector.spec
@@ -1,7 +1,3 @@
-%global snapshot 0
-%global commit bef7e39ce5fdc4a8a620d56be186d4463ed761a8
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
-
 Name:          abrt-java-connector
 Version:       1.2.0
 Release:       1%{?dist}
@@ -10,11 +6,7 @@ Summary:       JNI Agent library converting Java exceptions to ABRT problems
 Group:         System Environment/Libraries
 License:       GPLv2+
 URL:           https://github.com/abrt/abrt-java-connector
-%if 0%{?snapshot}
-Source0:       %{url}/archive/%{commit}/%{name}-%{version}-%{shortcommit}.tar.gz
-%else
 Source0:       %{url}/archive/%{version}/%{name}-%{version}.tar.gz
-%endif
 
 BuildRequires: pkgconfig(abrt) >= 2.14.1
 BuildRequires: check-devel
@@ -49,11 +41,7 @@ This package contains only minimal set of files needed for container exception
 logging.
 
 %prep
-%if 0%{?snapshot}
-%autosetup -n %{name}-%{commit}
-%else
-%autosetup
-%endif
+%autosetup -n %{name}-%{version}
 
 
 %build


### PR DESCRIPTION
This commit removes some globals from the spec which needed to be set by hand before release and moves the logic for determining (s)rpm version to the Makefile. Also, move the spec to the repo root.