### PR TITLE
Fix test

### DIFF
--- a/package/abrt-java-connector.spec
+++ b/package/abrt-java-connector.spec
@@ -61,8 +61,13 @@ logging.
 %cmake_build
 
 
+%check
+%ctest
+
+
 %install
 %cmake_install
+
 
 %files
 %doc README AUTHORS
@@ -94,13 +99,6 @@ logging.
 # Java does not support multilib.
 # https://fedorahosted.org/fesco/ticket/961
 %{_prefix}/lib/abrt-java-connector
-
-
-%check
-make test || {
-    cat Testing/Temporary/LastTest.log
-    exit 1
-}
 
 
 %changelog

--- a/test/outputs/run_test.log.in
+++ b/test/outputs/run_test.log.in
@@ -27,7 +27,7 @@ Exception in thread "main" java.io.FileNotFoundException: /root/.bashrc (Permiss
 	at Test.main(Test.java:513) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
 Caught exception java.net.UnknownHostException in method java.net.Inet4AddressImpl.lookupAllHostAddr()
-Exception in thread "main" java.net.UnknownHostException: xyzzy: Name or service not known
+Exception in thread "main" java.net.UnknownHostException: xyzzy: Temporary failure in name resolution
 	at java.base/java.net.Inet4AddressImpl.lookupAllHostAddr(Native Method) [jrt:/java.base/java/net/Inet4AddressImpl.class]
 	at java.base/java.net.InetAddress$PlatformNameService.lookupAllHostAddr(InetAddress.java:LINENO) [jrt:/java.base/java/net/InetAddress$PlatformNameService.class]
 	at java.base/java.net.InetAddress.getAddressesFromNameService(InetAddress.java:LINENO) [jrt:/java.base/java/net/InetAddress.class]


### PR DESCRIPTION
* Fix expected test output. It appears Java has changed the error message recently.
* Run tests during RPM build using `ctest`.