### PR TITLE
CMakeLists: Bump required libreport ver to 2.14.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ add_custom_target(
 
 include(FindPkgConfig)
 pkg_check_modules(PC_SATYR REQUIRED satyr)
-pkg_check_modules(PC_LIBREPORT REQUIRED libreport>=2.13.0)
+pkg_check_modules(PC_LIBREPORT REQUIRED libreport>=2.14.0)
 pkg_check_modules(PC_ABRT REQUIRED abrt>=2.14.1)
 
 add_definitions(-D_GNU_SOURCE)


### PR DESCRIPTION
Likely an oversight when updated in spec. This aligns the required
libreport version in both files.