### PR TITLE
tests: Accept all causes for UnknownHostException

### DIFF
--- a/test/outputs/Linux-aarch64/run_test.log.in
+++ b/test/outputs/Linux-aarch64/run_test.log.in
@@ -27,7 +27,7 @@ Exception in thread "main" java.io.FileNotFoundException: /root/.bashrc (Permiss
 	at Test.main(Test.java:513) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
 Caught exception java.net.UnknownHostException in method java.net.Inet4AddressImpl.lookupAllHostAddr()
-Exception in thread "main" java.net.UnknownHostException: xyzzy: Name or service not known
+Exception in thread "main" java.net.UnknownHostException: xyzzy
 	at java.net.Inet4AddressImpl.lookupAllHostAddr(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/Inet4AddressImpl.class]
 	at java.net.InetAddress$2.lookupAllHostAddr(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress$2.class]
 	at java.net.InetAddress.getAddressesFromNameService(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress.class]

--- a/test/outputs/Linux-armv7l/run_test.log.in
+++ b/test/outputs/Linux-armv7l/run_test.log.in
@@ -27,7 +27,7 @@ Exception in thread "main" java.io.FileNotFoundException: /root/.bashrc (Permiss
 	at Test.main(Test.java:513) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
 Caught exception java.net.UnknownHostException in method java.net.InetAddress$2.lookupAllHostAddr()
-Exception in thread "main" java.net.UnknownHostException: xyzzy: Name or service not known
+Exception in thread "main" java.net.UnknownHostException: xyzzy
 	at java.net.Inet4AddressImpl.lookupAllHostAddr(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/Inet4AddressImpl.class]
 	at java.net.InetAddress$2.lookupAllHostAddr(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress$2.class]
 	at java.net.InetAddress.getAddressesFromNameService(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress.class]

--- a/test/outputs/Linux-ppc/run_test.log.in
+++ b/test/outputs/Linux-ppc/run_test.log.in
@@ -24,7 +24,7 @@ Exception in thread "main" java.io.FileNotFoundException: /root/.bashrc (Permiss
 	at Test.main(Test.java:513) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
 Caught exception java.net.UnknownHostException in method java.net.InetAddress$2.lookupAllHostAddr()
-Exception in thread "main" java.net.UnknownHostException: xyzzy: unknown error
+Exception in thread "main" java.net.UnknownHostException: xyzzy
 	at java.net.Inet4AddressImpl.lookupAllHostAddr(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/Inet4AddressImpl.class]
 	at java.net.InetAddress$2.lookupAllHostAddr(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress$2.class]
 	at java.net.InetAddress.getAddressesFromNameService(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress.class]

--- a/test/outputs/Linux-ppc64/run_test.log.in
+++ b/test/outputs/Linux-ppc64/run_test.log.in
@@ -27,7 +27,7 @@ Exception in thread "main" java.io.FileNotFoundException: /root/.bashrc (Permiss
 	at Test.main(Test.java:513) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
 Caught exception java.net.UnknownHostException in method java.net.InetAddress$2.lookupAllHostAddr()
-Exception in thread "main" java.net.UnknownHostException: xyzzy: Name or service not known
+Exception in thread "main" java.net.UnknownHostException: xyzzy
 	at java.net.Inet4AddressImpl.lookupAllHostAddr(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/Inet4AddressImpl.class]
 	at java.net.InetAddress$2.lookupAllHostAddr(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress$2.class]
 	at java.net.InetAddress.getAddressesFromNameService(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress.class]

--- a/test/outputs/Linux-ppc64le/run_test.log.in
+++ b/test/outputs/Linux-ppc64le/run_test.log.in
@@ -27,7 +27,7 @@ Exception in thread "main" java.io.FileNotFoundException: /root/.bashrc (Permiss
 	at Test.main(Test.java:513) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
 Caught exception java.net.UnknownHostException in method java.net.InetAddress$2.lookupAllHostAddr()
-Exception in thread "main" java.net.UnknownHostException: xyzzy: Name or service not known
+Exception in thread "main" java.net.UnknownHostException: xyzzy
 	at java.net.Inet4AddressImpl.lookupAllHostAddr(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/Inet4AddressImpl.class]
 	at java.net.InetAddress$2.lookupAllHostAddr(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress$2.class]
 	at java.net.InetAddress.getAddressesFromNameService(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress.class]

--- a/test/outputs/Linux-s390/run_test.log.in
+++ b/test/outputs/Linux-s390/run_test.log.in
@@ -27,7 +27,7 @@ Exception in thread "main" java.io.FileNotFoundException: /root/.bashrc (Permiss
 	at Test.main(Test.java:513) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
 Caught exception java.net.UnknownHostException in method java.net.InetAddress$2.lookupAllHostAddr()
-Exception in thread "main" java.net.UnknownHostException: xyzzy: Name or service not known
+Exception in thread "main" java.net.UnknownHostException: xyzzy
 	at java.net.Inet4AddressImpl.lookupAllHostAddr(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/Inet4AddressImpl.class]
 	at java.net.InetAddress$2.lookupAllHostAddr(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress$2.class]
 	at java.net.InetAddress.getAddressesFromNameService(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress.class]

--- a/test/outputs/Linux-s390x/run_test.log.in
+++ b/test/outputs/Linux-s390x/run_test.log.in
@@ -27,7 +27,7 @@ Exception in thread "main" java.io.FileNotFoundException: /root/.bashrc (Permiss
 	at Test.main(Test.java:513) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
 Caught exception java.net.UnknownHostException in method java.net.InetAddress$2.lookupAllHostAddr()
-Exception in thread "main" java.net.UnknownHostException: xyzzy: Name or service not known
+Exception in thread "main" java.net.UnknownHostException: xyzzy
 	at java.net.Inet4AddressImpl.lookupAllHostAddr(Native Method) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/Inet4AddressImpl.class]
 	at java.net.InetAddress$2.lookupAllHostAddr(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress$2.class]
 	at java.net.InetAddress.getAddressesFromNameService(InetAddress.java:LINENO) [jar:file:JAVA_AND_SYSTEM_SPECIFIC_PATH/rt.jar!/java/net/InetAddress.class]

--- a/test/outputs/run_test.log.in
+++ b/test/outputs/run_test.log.in
@@ -27,7 +27,7 @@ Exception in thread "main" java.io.FileNotFoundException: /root/.bashrc (Permiss
 	at Test.main(Test.java:513) [file:@CMAKE_BINARY_DIR@/test/Test.class]
 executable: @CMAKE_BINARY_DIR@/test/Test.class
 Caught exception java.net.UnknownHostException in method java.net.Inet4AddressImpl.lookupAllHostAddr()
-Exception in thread "main" java.net.UnknownHostException: xyzzy: Temporary failure in name resolution
+Exception in thread "main" java.net.UnknownHostException: xyzzy
 	at java.base/java.net.Inet4AddressImpl.lookupAllHostAddr(Native Method) [jrt:/java.base/java/net/Inet4AddressImpl.class]
 	at java.base/java.net.InetAddress$PlatformNameService.lookupAllHostAddr(InetAddress.java:LINENO) [jrt:/java.base/java/net/InetAddress$PlatformNameService.class]
 	at java.base/java.net.InetAddress.getAddressesFromNameService(InetAddress.java:LINENO) [jrt:/java.base/java/net/InetAddress.class]

--- a/test/testdriver
+++ b/test/testdriver
@@ -24,7 +24,7 @@ if [ -n "$5" ] && [ 1 -eq $5 ]; then
                    { if (main == 1) { print $0 } }
 /\s*at .*\.main\(/ { if (main == 0) { print pfx$0; main = 1 } }
                    { pfx = "" }
-/^executable:/     { pfx = $0"\n" }' | tac > $TMP_RESULT
+/^executable:/     { pfx = $0"\n" }' | tac | sed -e '/java.net.UnknownHostException: xyzzy:/s/xyzzy: .*/xyzzy/' > $TMP_RESULT
 else
     cp $4 $TMP_RESULT
 fi


### PR DESCRIPTION
In some build environments, networking is restricted or disabled, which
can cause the UnknownHostException to be thrown with varying causes and
error messages. This commit filters out the error message from the test
result and also removes it from the reference files that we use to
evaluate the test. This way, we only check that the exception is thrown
as expected and the test doesn't fail when it's thrown for an unexpected
reason, e.g. "Name or service not known" vs. "Temporary failure in name
resolution".

See also bdacba19a48199434137961a555fe5755149792b.