### PR TITLE
Document test_unpackaged behaviour

### DIFF
--- a/README
+++ b/README
@@ -143,12 +143,15 @@ This project uses CMake build system but a Makefile for GNU Make, which defines
 all the targets you usually need to run, is also provided.
 
 $ make build
+$ make builddebug
 $ make run
 $ make check
 $ make rpm
 $ make distclean
 
 All build results are stored in ./bin directory.
+
+Use the `builddebug` make target if you wish to debug `bin/utils/abrt-action-analyze-java` with `gdb`.
 
 The `check' make target will fail if you run it under root user. There are some
 test cases that try to generate 'File Access Denied' exceptions and the easiest

--- a/README
+++ b/README
@@ -153,3 +153,5 @@ All build results are stored in ./bin directory.
 The `check' make target will fail if you run it under root user. There are some
 test cases that try to generate 'File Access Denied' exceptions and the easiest
 way to achieve that is to try to access a root's file.
+
+Also, the `check` target will fail if you're running it from anywhere under `/home`. This is because the satyr sr_java_stacktrace_parse function in the "unpackaged" test anonymizes the path to the java testing code which results in the test looking for a non-existent file under `/home/anonymized/`.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -333,7 +333,6 @@ _add_test(run_remote_thread 0)
 _add_analyze_test(not_reportable_1remote_class)
 _add_analyze_test(not_reportable_3remote_classes)
 _add_analyze_test(unusable)
-_add_analyze_test(unpackaged)
 
 _add_test_target(
     run_three_times
@@ -351,6 +350,8 @@ _add_test_target(
     AGENT_OPTIONS debugmethod=DataMethodTest.debugStringData
 )
 _add_test(run_data_method 2)
+
+_add_analyze_test(unpackaged)
 
 add_custom_target(
     run_jar_relative

--- a/test/outputs/not_reportable_1remote_class.log.in
+++ b/test/outputs/not_reportable_1remote_class.log.in
@@ -3,4 +3,4 @@ duphash
 uuid
 4bd13090ba6559c9c9023926671295559a25bc9b
 not-reportable
-This problem can be caused by a 3rd party code from the jar/class at http://localhost:54321/JarTest.jar. In order to provide valuable problem reports, ABRT will not allow you to submit this problem. If you still want to participate in solving this problem, please contact the developers directly.
+This problem can be caused by 3rd party code from the jar/class at http://localhost:54321/JarTest.jar. In order to provide valuable problem reports, ABRT will not allow you to submit this problem. If you still want to participate in solving this problem, please contact the developers directly.

--- a/test/outputs/not_reportable_3remote_classes.log.in
+++ b/test/outputs/not_reportable_3remote_classes.log.in
@@ -3,4 +3,4 @@ duphash
 uuid
 4bd13090ba6559c9c9023926671295559a25bc9b
 not-reportable
-This problem can be caused by a 3rd party code from the jar/class at http://localhost:54321/JarTest.jar, http://localhost:321/JarTest.jar, http://localhost:4321/JarTest.jar. In order to provide valuable problem reports, ABRT will not allow you to submit this problem. If you still want to participate in solving this problem, please contact the developers directly.
+This problem can be caused by 3rd party code from the jar/class at http://localhost:54321/JarTest.jar, http://localhost:321/JarTest.jar, http://localhost:4321/JarTest.jar. In order to provide valuable problem reports, ABRT will not allow you to submit this problem. If you still want to participate in solving this problem, please contact the developers directly.

--- a/test/outputs/unpackaged.log.in
+++ b/test/outputs/unpackaged.log.in
@@ -3,4 +3,4 @@ duphash
 uuid
 11977a37eb1291bbb6183875fc3b2d774564c4b7
 not-reportable
-This problem has been caused by a proprietary code which has not been provided any official package. Please contact the provider of the proprietary code.
+This problem was caused by proprietary code not provided by any official package. Please contact the author of the proprietary code.

--- a/utils/abrt-action-analyze-java.c
+++ b/utils/abrt-action-analyze-java.c
@@ -357,7 +357,7 @@ int main(int argc, char *argv[])
     {
         results_iter->name = FILENAME_NOT_REPORTABLE;
         results_iter->data = g_strdup_printf(
-        _("This problem can be caused by a 3rd party code from the "\
+        _("This problem can be caused by 3rd party code from the "\
         "jar/class at %s. In order to provide valuable problem " \
         "reports, ABRT will not allow you to submit this problem. If you " \
         "still want to participate in solving this problem, please contact " \
@@ -381,8 +381,8 @@ int main(int argc, char *argv[])
     {
         results_iter->name = FILENAME_NOT_REPORTABLE;
         results_iter->data = g_strdup_printf(
-        _("This problem has been caused by a proprietary code which has not been "
-        "provided any official package. Please contact the provider of the "
+        _("This problem was caused by proprietary code not "
+        "provided by any official package. Please contact the author of the "
         "proprietary code.")
         );
         ++results_iter;


### PR DESCRIPTION
See commits. We were dealing with this a long time ago and now it threw me off again after I'd already forgotten the details. The proper solution would be to use `tito` for building but this should save people some trouble in the meantime.